### PR TITLE
improve XPCoin logo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,11 @@ manuscript.tex: manuscript.md
 #.png.eps:
 #	convert $< $(<.png=.eps)
 ms-icon-310x310.eps:
-	convert ms-icon-310x310.png ms-icon-310x310.eps
+	convert ms-icon-310x310.png ms-icon-310x310.svg
+	convert ms-icon-310x310.svg ms-icon-310x310.eps
 
 view: $(PDF)
 	open $(PDF)
 
 clean:
-	/bin/rm -f $(DVI) $(PDF) *.out *.aux *.log manuscript.tex *.eps
+	/bin/rm -f $(DVI) $(PDF) *.out *.aux *.log manuscript.tex *.eps *.svg

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ $(PDF): $(DVI)
 $(DVI): $(TEX) manuscript.tex ms-icon-310x310.eps
 	platex $(TEX)
 
-manuscript.tex: 
+manuscript.tex: manuscript.md
 	@cat manuscript.md \
  	| sed s/.png/.eps/g \
 	| pandoc -t latex \

--- a/XPCoin-Whitepaper-ja.tex
+++ b/XPCoin-Whitepaper-ja.tex
@@ -5,6 +5,7 @@
 \usepackage{graphicx}
 \usepackage{ascmac}
 \usepackage[dvipdfm]{hyperref}
+\def\tightlist{\itemsep1pt\parskip0pt\parsep0pt}
 
 \title {XP Whitepaper v3}
 \author {xpjp}


### PR DESCRIPTION
- png -> svg -> eps で変換しジャギを目立たないようにしました。
- `tightlist` を定義してビルドが止まるのを解消しました。

# 改善前
<img width="1470" alt="2017-12-26 0 33 56" src="https://user-images.githubusercontent.com/129496/34359365-d01158ca-ea9a-11e7-9e1c-2a884faf71bd.png">

# 改善後
<img width="1470" alt="2017-12-26 23 52 29" src="https://user-images.githubusercontent.com/129496/34359358-baf7eb0c-ea9a-11e7-9363-ea884c5cb4cb.png">
